### PR TITLE
Add player count poller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 agent.log
+player_count.csv

--- a/README.md
+++ b/README.md
@@ -19,3 +19,16 @@ log_action('Agent started task')
 step. Running the module will attempt to contact `sky.shiiyu.moe`, which may
 fail due to the site's Cloudflare protection. Logged messages record the
 result of the request.
+
+## Polling player count
+
+`player_count_poller.py` polls the online player count for a Minecraft server
+using the [mcsrvstat.us](https://mcsrvstat.us/) API. Results are appended to
+`player_count.csv` with a timestamp. The script waits roughly one minute
+between requests with a small amount of random jitter.
+
+Run the module directly to begin polling:
+
+```bash
+python player_count_poller.py
+```

--- a/player_count_poller.py
+++ b/player_count_poller.py
@@ -1,0 +1,48 @@
+import csv
+import random
+import time
+from datetime import datetime
+from typing import Optional
+
+import requests
+
+from agent_logger import log_action
+
+API_URL_TEMPLATE = "https://api.mcsrvstat.us/2/{server}"
+CSV_FILE = "player_count.csv"
+
+def fetch_player_count(server: str) -> Optional[int]:
+    """Return the number of players currently online for the server."""
+    url = API_URL_TEMPLATE.format(server=server)
+    log_action(f"Requesting {url}")
+    try:
+        response = requests.get(url, timeout=10, headers={"User-Agent": "Mozilla/5.0"})
+        log_action(f"Received status {response.status_code} from {url}")
+        response.raise_for_status()
+        data = response.json()
+        return data.get("players", {}).get("online")
+    except requests.RequestException as exc:
+        log_action(f"Failed to fetch player count: {exc}")
+        return None
+
+def append_to_csv(timestamp: str, count: Optional[int]) -> None:
+    """Append a timestamp and player count to the CSV file."""
+    with open(CSV_FILE, "a", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow([timestamp, count if count is not None else ""])
+
+
+def poll_player_count(server: str) -> None:
+    """Continuously poll player count roughly every minute with jitter."""
+    while True:
+        timestamp = datetime.utcnow().isoformat()
+        count = fetch_player_count(server)
+        append_to_csv(timestamp, count)
+        # sleep for about one minute with random jitter
+        delay = 60 + random.uniform(-10, 10)
+        log_action(f"Sleeping for {delay:.2f} seconds")
+        time.sleep(delay)
+
+
+if __name__ == "__main__":
+    poll_player_count("play.hypixel.net")


### PR DESCRIPTION
## Summary
- ignore CSV data from polling
- document polling new script in README
- add `player_count_poller.py` to repeatedly capture player counts with random delay

## Testing
- `python -m py_compile agent_logger.py skycrypt_fetcher.py player_count_poller.py`

------
https://chatgpt.com/codex/tasks/task_e_683fb71b2cbc83339e20370149f1b3f2